### PR TITLE
Android message encoding

### DIFF
--- a/android/src/main/java/infozenplus/com/flutter_open_whatsapp/FlutterOpenWhatsappPlugin.java
+++ b/android/src/main/java/infozenplus/com/flutter_open_whatsapp/FlutterOpenWhatsappPlugin.java
@@ -1,5 +1,8 @@
 package infozenplus.com.flutter_open_whatsapp;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -42,8 +45,9 @@ public class FlutterOpenWhatsappPlugin implements MethodCallHandler {
       try {
         String mobileNo = call.argument("mobileNo");
         String message = call.argument("message");
+        String encodedMessage = URLEncoder.encode(message, StandardCharsets.UTF_8.toString());
         //https://wa.me/919167370647?text=Yes%20We'll%20do%20this%20in%20frag4%20inOCW
-        String url = "https://wa.me/" + mobileNo.trim() + "?text=" + message.trim();
+        String url = "https://wa.me/" + mobileNo.trim() + "?text=" + encodedMessage;
         i.setPackage("com.whatsapp");
         i.setData(Uri.parse(url));
         if (i.resolveActivity(packageManager) != null) {

--- a/ios/Classes/SwiftFlutterOpenWhatsappPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpenWhatsappPlugin.swift
@@ -2,41 +2,44 @@ import Flutter
 import UIKit
 
 public class SwiftFlutterOpenWhatsappPlugin: NSObject, FlutterPlugin {
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "flutter_open_whatsapp", binaryMessenger: registrar.messenger())
-    let instance = SwiftFlutterOpenWhatsappPlugin()
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-  if(call.method == "getPlatformVersion"){
-    result("iOS " + UIDevice.current.systemVersion)
-    } else if(call.method == "sendSingleMessage"){
-
-    DispatchQueue.main.async{
-
-          //let mobileNo: String = args["mobileNo"];
-          //let message: String = args["message"];
-
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "flutter_open_whatsapp", binaryMessenger: registrar.messenger())
+        let instance = SwiftFlutterOpenWhatsappPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+    
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if(call.method == "getPlatformVersion"){
+            result("iOS " + UIDevice.current.systemVersion)
+        } else if(call.method == "sendSingleMessage"){
+            
+            DispatchQueue.main.async{
+                
+                //let mobileNo: String = args["mobileNo"];
+                //let message: String = args["message"];
+                
                 guard let args = call.arguments else {
-                  return
+                    return
                 }
                 if let myArgs = args as? [String: Any],
-                   let mobileNo = myArgs["mobileNo"] as? String,
-                   let message = myArgs["message"] as? String {
-                  //result("Params received on iOS = \(someInfo1), \(someInfo2)")
-
-          let whatsAppUrl = NSURL(string: "https://wa.me/" + mobileNo.trimmingCharacters(in: .whitespaces) + "?text=" + message.trimmingCharacters(in: .whitespaces))
-          if UIApplication.shared.canOpenURL(whatsAppUrl as! URL) {
-                UIApplication.shared.openURL(whatsAppUrl as! URL)
-          }else {
-              //let errorAlert = UIAlertView(title: "Sorry", message: "You can't send a message to this number", delegate: self, cancelButtonTitle:"Ok")
-               // errorAlert.show()
-               print("Install Whatsapp")
+                    let mobileNo = myArgs["mobileNo"] as? String,
+                    let message = myArgs["message"] as? String {
+                    //result("Params received on iOS = \(someInfo1), \(someInfo2)")
+                    let url: String = ("https://wa.me/" + mobileNo + "?text=" + (message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""))
+                    if let whatsAppUrl = URL(string: url) {
+                        if UIApplication.shared.canOpenURL(whatsAppUrl) {
+                            UIApplication.shared.openURL(whatsAppUrl)
+                        }else {
+                            //let errorAlert = UIAlertView(title: "Sorry", message: "You can't send a message to this number", delegate: self, cancelButtonTitle:"Ok")
+                            // errorAlert.show()
+                            result("Please, install whatsapp")
+                        }
+                    } else {
+                        result("Something happened")
                     }
-      }
+                }
+            }
+        }
     }
-  }
-}
-
+    
 }

--- a/ios/Classes/SwiftFlutterOpenWhatsappPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpenWhatsappPlugin.swift
@@ -25,7 +25,7 @@ public class SwiftFlutterOpenWhatsappPlugin: NSObject, FlutterPlugin {
                     let mobileNo = myArgs["mobileNo"] as? String,
                     let message = myArgs["message"] as? String {
                     //result("Params received on iOS = \(someInfo1), \(someInfo2)")
-                    let url: String = ("https://wa.me/" + mobileNo + "?text=" + (message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""))
+                    let url: String = ("https://wa.me/" + mobileNo + "?text=" + (message.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? ""))
                     if let whatsAppUrl = URL(string: url) {
                         if UIApplication.shared.canOpenURL(whatsAppUrl) {
                             UIApplication.shared.openURL(whatsAppUrl)


### PR DESCRIPTION
Messages sent via android were not encoded at all. This caused problems when having URL sensitive characters (e.g. `?`) in the text.

fixes https://github.com/rohit1814/flutter_open_whatsapp/issues/10